### PR TITLE
Add the app in the default state

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock "~> 3.19.1"
 
 set :application, "TaskBridge"
-set :repo_url, "https://github.com/Kanyorok/TaskBridgeApp.git"
+set :repo_url, "https://github.com/Kanyorok/TaskBridgeApplication.git"
 set :branch, 'dev'
 
 # Default branch is :master


### PR DESCRIPTION
This pull request updates the deployment configuration to point to the correct GitHub repository for the application.

Configuration update:

* Changed the `:repo_url` in `config/deploy.rb` to use `https://github.com/Kanyorok/TaskBridgeApplication.git` instead of the previous repository URL.