### PR TITLE
Add the logic for staging the application

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,4 +1,4 @@
 server "172.16.2.15", user: "taskbridgetest", roles: %w{app db web}
 
 set :rails_env, "staging"
-set :branch, "dev"  # Or whatever branch you deploy to staging
+set :branch, "dev" 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,10 @@
+require_relative "production"
+
+Rails.application.configure do
+  config.eager_load = true
+  config.cache_classes = true
+  config.consider_all_requests_local = false
+  config.assets.compile = false
+  config.assets.digest = true
+  # Add other production-like settings as needed
+end


### PR DESCRIPTION
This pull request updates the staging environment configuration to more closely mirror production settings, ensuring better parity and reliability when testing deployments. The changes primarily focus on loading production settings for staging and tightening asset and class loading behaviors.

Staging environment configuration:

* Added a new `config/environments/staging.rb` file that requires the production configuration and sets staging-specific overrides, such as enabling eager loading, class caching, disabling asset compilation, and enabling asset digests.

Deployment settings:

* Minor formatting change in `config/deploy/staging.rb` to remove a comment and ensure the staging branch is set to `dev`.